### PR TITLE
Add basic Next.js UI

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,12 @@
+# Ape Fun Launchpad UI
+
+This folder contains a minimal Next.js interface for interacting with the smart contracts in the root of this repository. It provides a Solana wallet connection, a sample chart component and a button to create a token using the provided library utilities.
+
+## Getting Started
+
+```
+yarn install
+yarn dev
+```
+
+Set the `KEYPAIR` and `RPC_URL` environment variables to point to your wallet and preferred RPC endpoint. The UI connects to devnet by default.

--- a/ui/components/Chart.tsx
+++ b/ui/components/Chart.tsx
@@ -1,0 +1,19 @@
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
+
+const data = [
+  { name: 'Day 1', value: 400 },
+  { name: 'Day 2', value: 300 },
+  { name: 'Day 3', value: 500 },
+];
+
+export default function Chart() {
+  return (
+    <LineChart width={500} height={300} data={data}>
+      <CartesianGrid stroke="#ccc" />
+      <XAxis dataKey="name" />
+      <YAxis />
+      <Tooltip />
+      <Line type="monotone" dataKey="value" stroke="#8884d8" />
+    </LineChart>
+  );
+}

--- a/ui/components/TokenCreator.tsx
+++ b/ui/components/TokenCreator.tsx
@@ -1,0 +1,33 @@
+import { useConnection, useWallet } from '@solana/wallet-adapter-react';
+import { Button } from '@solana/wallet-adapter-react-ui';
+import { Transaction } from '@solana/web3.js';
+import { useState } from 'react';
+
+export default function TokenCreator() {
+  const { connection } = useConnection();
+  const { publicKey, sendTransaction } = useWallet();
+  const [loading, setLoading] = useState(false);
+
+  const onCreate = async () => {
+    if (!publicKey) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/api/create-token', { method: 'POST' });
+      const { tx } = await res.json();
+      const transaction = Transaction.from(Buffer.from(tx, 'base64'));
+      await sendTransaction(transaction, connection);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ marginTop: '1rem' }}>
+      <Button disabled={!publicKey || loading} onClick={onCreate}>
+        Create Token
+      </Button>
+    </div>
+  );
+}

--- a/ui/next-env.d.ts
+++ b/ui/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "ape-fun-ui",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@solana/web3.js": "^1.89.0",
+    "@solana/wallet-adapter-react": "^0.15.31",
+    "@solana/wallet-adapter-react-ui": "^0.15.31",
+    "@solana/wallet-adapter-wallets": "^0.15.31",
+    "recharts": "^2.6.2",
+    "@coral-xyz/anchor": "^0.30.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "@types/react": "^18.0.26",
+    "@types/react-dom": "^18.0.9",
+    "@types/node": "^18.0.0"
+  }
+}

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -1,0 +1,23 @@
+import type { AppProps } from 'next/app';
+import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
+import {
+  WalletModalProvider,
+  WalletMultiButton,
+} from '@solana/wallet-adapter-react-ui';
+import { PhantomWalletAdapter } from '@solana/wallet-adapter-wallets';
+import { clusterApiUrl } from '@solana/web3.js';
+import '@solana/wallet-adapter-react-ui/styles.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  const endpoint = process.env.NEXT_PUBLIC_RPC_URL || clusterApiUrl('devnet');
+  const wallets = [new PhantomWalletAdapter()];
+  return (
+    <ConnectionProvider endpoint={endpoint}>
+      <WalletProvider wallets={wallets} autoConnect>
+        <WalletModalProvider>
+          <Component {...pageProps} />
+        </WalletModalProvider>
+      </WalletProvider>
+    </ConnectionProvider>
+  );
+}

--- a/ui/pages/api/create-token.ts
+++ b/ui/pages/api/create-token.ts
@@ -1,0 +1,56 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createBondingCurveTx } from "../../../lib/scripts";
+import {
+  TEST_DECIMALS,
+  TEST_TOKEN_SUPPLY,
+  TEST_VIRTUAL_RESERVES,
+  TEST_NAME,
+  TEST_SYMBOL,
+  TEST_URI,
+} from "../../../lib/constant";
+import { Program, AnchorProvider } from "@coral-xyz/anchor";
+import NodeWallet from "@coral-xyz/anchor/dist/cjs/nodewallet";
+import { Connection, Keypair } from "@solana/web3.js";
+import fs from "fs";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    const keypairPath = process.env.KEYPAIR || "id.json";
+    const secret = Uint8Array.from(
+      JSON.parse(fs.readFileSync(keypairPath, "utf-8")),
+    );
+    const wallet = new NodeWallet(Keypair.fromSecretKey(secret));
+    const connection = new Connection(
+      process.env.RPC_URL || "https://api.devnet.solana.com",
+    );
+    const provider = new AnchorProvider(connection, wallet, {
+      skipPreflight: true,
+      commitment: "confirmed",
+    });
+    const idl = JSON.parse(
+      fs.readFileSync("target/idl/pump_raydium.json", "utf-8"),
+    );
+    const program = new Program(idl, idl.metadata.address, provider);
+
+    const tx = await createBondingCurveTx(
+      TEST_DECIMALS,
+      TEST_TOKEN_SUPPLY,
+      TEST_VIRTUAL_RESERVES,
+      TEST_NAME,
+      TEST_SYMBOL,
+      TEST_URI,
+      wallet.publicKey,
+      wallet.publicKey,
+      connection,
+      program,
+    );
+    const raw = tx.serialize({ verifySignatures: false }).toString("base64");
+    res.status(200).json({ tx: raw });
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -1,0 +1,18 @@
+import Head from 'next/head';
+import { WalletMultiButton } from '@solana/wallet-adapter-react-ui';
+import Chart from '../components/Chart';
+import TokenCreator from '../components/TokenCreator';
+
+export default function Home() {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <Head>
+        <title>Ape Fun Launchpad</title>
+      </Head>
+      <WalletMultiButton />
+      <h1>Ape Fun Launchpad</h1>
+      <Chart />
+      <TokenCreator />
+    </div>
+  );
+}

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add simple Next.js app under `ui/` for web interaction
- include wallet connection, chart and token creation UI
- expose API route to create a token using existing library
- document how to run the UI

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6852f5d3028483279b3cd656d655dd31